### PR TITLE
Update macOS compatibility

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,5 @@ LICENSE
 known_issues.Rmd
 tic.R
 _pkgdown.yml
+^appveyor\.yml$
+^tic\.R$

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
   # tap osgeo4mac tap
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew tap osgeo/osgeo4mac; fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink proj && brew unlink libgeotiff && brew unlink libspatialite && brew unlink postgresql && brew unlink gdal && brew unlink postgis; fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then sudo rm -rf /usr/local/gfortran/bin/gfortran && sudo rm /usr/local/include/c++; fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then ulimit -n 1200 && brew install osgeo-qgis-ltr; fi
 
 install: R -q -e 'tic::install()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
       - libudunits2-dev
       - python-gdal
       - saga
+      - grass
 
 # DO NOT CHANGE THE CODE BELOW
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,18 @@
 # tic documentation to get started: https://ropenscilabs.github.io/tic/
 # Usually you shouldn't need to change the first part of the file
 
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntugis/ubuntugis-unstable'
+      - sourceline: 'deb http://qgis.org/ubuntugis-ltr xenial main'
+        key_url: 'http://qgis.org/downloads/qgis-2019.gpg.key'
+    packages:
+      - libgdal-dev
+      - libudunits2-dev
+      - python-gdal
+      - saga
+
 # DO NOT CHANGE THE CODE BELOW
 before_install:
   - R -q -e 'if (!requireNamespace("remotes")) install.packages("remotes")'
@@ -25,14 +37,49 @@ after_deploy: R -q -e 'tic::after_deploy()'
 after_script: R -q -e 'tic::after_script()'
 # DO NOT CHANGE THE CODE ABOVE
 
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      latex: false
+      env: linux=true
+      install: R -q -e 'tic::install()'
+      after_install: R -q -e 'tic::after_install()'
+      script: R -q -e 'tic::script()'
+      before_deploy: R -q -e 'tic::before_deploy()'
+      deploy:
+          provider: script
+          script: R -q -e 'tic::deploy()'
+          on:
+            branches: master
+            condition:
+               - $TRAVIS_PULL_REQUEST = false
+               - $TRAVIS_EVENT_TYPE != cron
+      after_deploy: R -q -e 'tic::after_deploy()'
+      after_script: R -q -e 'tic::after_script()'
+      after_success: R -q -e 'tic::after_success()'
+
+    ### build QGIS DEV on macOS
+    - os: osx
+      latex: false
+      sudo: false
+      env: mac=true
+      install: R -q -e 'tic::install()'
+      after_install: R -q -e 'tic::after_install()'
+      script: R -q -e 'tic::script()'
 # Custom parts:
 
-# Header
-language: r
-sudo: false
-dist: xenial
-cache: packages
-latex: false
+before_install:
+  # install latest qgis-ltr using aptitude to resolve dependencies
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo aptitude install -y qgis python-qgis; fi
+
+  #############
+  # OSX
+  #############
+
+  # tap osgeo4mac tap
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew tap osgeo/osgeo4mac; fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install osgeo-qgis-ltr; fi
 
 #env
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   # tap osgeo4mac tap
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew tap osgeo/osgeo4mac; fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink proj && brew unlink libgeotiff && brew unlink libspatialite && brew unlink postgresql && brew unlink gdal && brew unlink postgis; fi
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install osgeo-qgis-ltr; fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then ulimit -n 1200 && brew install osgeo-qgis-ltr; fi
 
 install: R -q -e 'tic::install()'
 after_install: R -q -e 'tic::after_install()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,3 +91,4 @@ env:
 
 #services
 services:
+  - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ before_install:
 
     # install latest qgis-ltr using aptitude to resolve dependencies
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo aptitude install -y qgis python-qgis; fi
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 
   #############
   # OSX
@@ -41,7 +38,11 @@ before_install:
 
 install: R -q -e 'tic::install()'
 after_install: R -q -e 'tic::after_install()'
-before_script: R -q -e 'tic::before_script()'
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+  - R -q -e 'tic::before_script()'
 script: R -q -e 'tic::script()'
 after_success: R -q -e 'tic::after_success()'
 after_failure: R -q -e 'tic::after_failure()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   # tap osgeo4mac tap
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew tap osgeo/osgeo4mac; fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink proj && brew unlink libgeotiff && brew unlink libspatialite && brew unlink postgresql && brew unlink gdal && brew unlink postgis; fi
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then sudo rm -rf /usr/local/gfortran/bin/gfortran && sudo rm /usr/local/include/c++; fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then sudo rm -rf /usr/local/gfortran/bin/gfortran; fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then ulimit -n 1200 && brew install osgeo-qgis-ltr; fi
 
 install: R -q -e 'tic::install()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ install: R -q -e 'tic::install()'
 after_install: R -q -e 'tic::after_install()'
 before_script:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sh -e /etc/init.d/xvfb start; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi
   - sleep 3 # give xvfb some time to start
   - R -q -e 'tic::before_script()'
 script: R -q -e 'tic::script()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 # tic documentation to get started: https://ropenscilabs.github.io/tic/
 # Usually you shouldn't need to change the first part of the file
 
+language: r
+cache: packages
+
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ before_install:
 
     # install latest qgis-ltr using aptitude to resolve dependencies
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo aptitude install -y qgis python-qgis; fi
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
   #############
   # OSX

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
 
   # tap osgeo4mac tap
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew tap osgeo/osgeo4mac; fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew unlink proj && brew unlink libgeotiff && brew unlink libspatialite && brew unlink postgresql && brew unlink gdal && brew unlink postgis; fi
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install osgeo-qgis-ltr; fi
 
 install: R -q -e 'tic::install()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,102 +1,43 @@
 # R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
-language: r		 
-cache: packages	
+# Default configuration for use with tic package
+# tic documentation to get started: https://ropenscilabs.github.io/tic/
+# Usually you shouldn't need to change the first part of the file
 
-addons:
-  apt:
-    sources:
-      - sourceline: 'ppa:ubuntugis/ubuntugis-unstable'
-      - sourceline: 'deb http://qgis.org/ubuntugis-ltr trusty main'
-        key_url: 'http://qgis.org/downloads/qgis-2017.gpg.key'
-    packages:
-      - libgdal-dev
-      - libudunits2-dev
-      - python-gdal
-      - saga
-      - equivs
-
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-      latex: false
-      env: linux=true
-      install: R -q -e 'tic::install()'
-      after_install: R -q -e 'tic::after_install()'
-      script: R -q -e 'tic::script()'
-      before_deploy: R -q -e 'tic::before_deploy()'
-      deploy:
-          provider: script
-          script: R -q -e 'tic::deploy()'
-          on:
-            branches: master
-            condition:
-               - $TRAVIS_PULL_REQUEST = false
-               - $TRAVIS_EVENT_TYPE != cron
-      after_deploy: R -q -e 'tic::after_deploy()'
-      after_script: R -q -e 'tic::after_script()'
-      after_success: R -q -e 'tic::after_success()'
-
-    ### build QGIS DEV on macOS
-    - os: osx
-      latex: false
-      sudo: false
-      env: mac=true
-      install: R -q -e 'tic::install()'
-      after_install: R -q -e 'tic::after_install()'
-      script: R -q -e 'tic::script()'
-
-# if we install everything from ubuntugis-unstable PPA, we get GDAL2 but only QGIS 2.14.X for trusty
-# if we install everything from qgis.org/ubuntugis-ltr, we get most recent QGIS but missing GDAL2
-
+# DO NOT CHANGE THE CODE BELOW
 before_install:
-  # we need to fake gdal-abi-2-1-3 as qgis won't find it otherwise because it searches for gdal20
-  # see https://gis.stackexchange.com/questions/216780/cannot-install-qgis-2-18-from-repository-on-debian-stretch-package-gdal-abi-2
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then chmod ugo+x inst/travis/gdal-abi.sh; fi
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then ./inst/travis/gdal-abi.sh; fi
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo equivs-build gdal-abi.control && sudo sudo dpkg -i gdal-abi-2-1-0_2.1.0_all.deb && sudo rm -rf gdal-abi-2-1-0_2.1.0_all.deb && sudo rm -rf gdal-abi.control; fi
-    
-  # install latest qgis-ltr using aptitude to resolve dependencies
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo aptitude install -y qgis python-qgis; fi  
-  
-  #############
-  # OSX
-  #############
-  
-  # tap osgeo4mac tap
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew tap osgeo/osgeo4mac; fi
-   
-  # install saga-gis-lts
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install saga-gis-lts && brew link saga-gis-lts --force; fi
-  
-  # we need python2
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install python@2; fi
-  # install required python packages
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then pip2 install --user psycopg2 future matplotlib pyparsing gdal pyyaml jinja2 owslib pygments; fi
-  
-    # Solve gfortran conflict
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then sudo rm -rf /usr/local/gfortran/bin/gfortran && sudo rm /usr/local/include/c++; fi
-  # install grass7 and unlink it so that the QGIS linking later on works
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install grass7 && brew unlink grass7; fi
-  # install qgis2
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install qgis2; fi
-  
-  
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew link --overwrite --force gdal2; fi
-  - R -q -e 'install.packages("remotes"); remotes::install_github("ropenscilabs/tic"); tic::prepare_all_stages(); tic::before_install()'
-  
-# imitate a X virtual display -> https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
-before_script:
-  - "export DISPLAY=:99.0"
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sh -e /etc/init.d/xvfb start; fi
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi
-  - sleep 3 # give xvfb some time to start
-  
-notifications:
-  slack:
-      rooms:
-        - giscience-fsu:3GsmuFR1hkVOUHOPwdra8NXG #rqgis
-  on_success: change # default: always
-  on_failure: change # default: always
-  email: false
+  - R -q -e 'if (!requireNamespace("remotes")) install.packages("remotes")'
+  - R -q -e 'if (getRversion() < "3.2" && !requireNamespace("curl")) install.packages("curl")'
+  - R -q -e 'remotes::install_github("ropenscilabs/tic", upgrade = "always"); print(tic::dsl_load()); tic::prepare_all_stages()'
+  - R -q -e 'tic::before_install()'
+install: R -q -e 'tic::install()'
+after_install: R -q -e 'tic::after_install()'
+before_script: R -q -e 'tic::before_script()'
+script: R -q -e 'tic::script()'
+after_success: R -q -e 'tic::after_success()'
+after_failure: R -q -e 'tic::after_failure()'
+before_deploy: R -q -e 'tic::before_deploy()'
+deploy:
+  provider: script
+  script: R -q -e 'tic::deploy()'
+  on:
+    all_branches: true
+after_deploy: R -q -e 'tic::after_deploy()'
+after_script: R -q -e 'tic::after_script()'
+# DO NOT CHANGE THE CODE ABOVE
+
+# Custom parts:
+
+# Header
+language: r
+sudo: false
+dist: xenial
+cache: packages
+latex: false
+
+#env
+env:
+  global:
+  - MAKEFLAGS="-j 2"
+
+#services
+services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,7 @@ before_install:
 install: R -q -e 'tic::install()'
 after_install: R -q -e 'tic::after_install()'
 before_script:
-  - "export DISPLAY=:99.0"
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sh -e /etc/init.d/xvfb start; fi
+  - export DISPLAY=:99.0
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& fi
   - sleep 3 # give xvfb some time to start
   - R -q -e 'tic::before_script()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,18 @@ before_install:
   - R -q -e 'if (getRversion() < "3.2" && !requireNamespace("curl")) install.packages("curl")'
   - R -q -e 'remotes::install_github("ropenscilabs/tic", upgrade = "always"); print(tic::dsl_load()); tic::prepare_all_stages()'
   - R -q -e 'tic::before_install()'
+
+    # install latest qgis-ltr using aptitude to resolve dependencies
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo aptitude install -y qgis python-qgis; fi
+
+  #############
+  # OSX
+  #############
+
+  # tap osgeo4mac tap
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew tap osgeo/osgeo4mac; fi
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install osgeo-qgis-ltr; fi
+
 install: R -q -e 'tic::install()'
 after_install: R -q -e 'tic::after_install()'
 before_script: R -q -e 'tic::before_script()'
@@ -71,18 +83,6 @@ matrix:
       after_install: R -q -e 'tic::after_install()'
       script: R -q -e 'tic::script()'
 # Custom parts:
-
-before_install:
-  # install latest qgis-ltr using aptitude to resolve dependencies
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then sudo aptitude install -y qgis python-qgis; fi
-
-  #############
-  # OSX
-  #############
-
-  # tap osgeo4mac tap
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew tap osgeo/osgeo4mac; fi
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then brew install osgeo-qgis-ltr; fi
 
 #env
 env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,52 +1,56 @@
-Package: RQGIS3
-Date: 2018-08-14
 Type: Package
+Package: RQGIS3
 Title: Integrating R with QGIS3
 Version: 1.0.1.9000
-Authors@R: c(
-    person("Jannes", "Muenchow",
-    email = "jannes.muenchow@uni-jena.de", 
-    role = c("aut", "cre"),
-    comment = c(ORCID = '0000-0001-7834-4717')),
-    person("Patrick", "Schratz", ,
-    email = "patrick.schratz@uni-jena.de", 
-    role = c("aut"),
-    comment = c(ORCID = '0000-0003-0748-6624')
-    ))
-Description: Establishes an interface between R and 'QGIS', i.e. it allows
-    the user to access 'QGIS' functionalities from the R console. It achieves this
-    by using the 'QGIS' Python API via the command line. Hence, RQGIS extends R's
-    statistical power by the incredible vast geo-functionality of 'QGIS' (including
-    also 'GDAL', 'SAGA'- and 'GRASS'-GIS among other third-party providers).
-    This in turn creates a powerful environment for advanced and innovative
-    (geo-)statistical geocomputing. 'QGIS' is licensed under GPL version 2 or
-    greater and is available from <http://www.qgis.org/en/site/>.
+Date: 2018-08-14
+Authors@R: 
+    c(person(given = "Jannes",
+             family = "Muenchow",
+             role = c("aut", "cre"),
+             email = "jannes.muenchow@uni-jena.de",
+             comment = c(ORCID = "0000-0001-7834-4717")),
+      person(given = "Patrick",
+             family = "Schratz",
+             role = "aut",
+             email = "patrick.schratz@uni-jena.de",
+             comment = c(ORCID = "0000-0003-0748-6624")))
+Description: Establishes an interface between R and 'QGIS', i.e.
+    it allows the user to access 'QGIS' functionalities from the R
+    console. It achieves this by using the 'QGIS' Python API via the
+    command line. Hence, RQGIS extends R's statistical power by the
+    incredible vast geo-functionality of 'QGIS' (including also 'GDAL',
+    'SAGA'- and 'GRASS'-GIS among other third-party providers).  This in
+    turn creates a powerful environment for advanced and innovative
+    (geo-)statistical geocomputing. 'QGIS' is licensed under GPL version 2
+    or greater and is available from <http://www.qgis.org/en/site/>.
+License: GPL-3
 URL: https://github.com/jannes-m/RQGIS3
 BugReports: https://github.com/jannes-m/RQGIS3/issues
-License: GPL-3
-LazyData: TRUE
-Encoding: UTF-8
-RoxygenNote: 6.1.1
-Roxygen: list(markdown = TRUE)
-ByteCompile: true
 Depends:
     R (>= 3.2.0),
     reticulate (>= 1.2)
 Imports:
-         raster,
-         RCurl,
-         readr,
-         rgdal,
-         sf (>= 0.4-2),
-         sp,
-         stringr,
-         tools,
-         XML
-SystemRequirements: Python (>= 3.4), QGIS (>= 3.5)
+    raster,
+    RCurl,
+    readr,
+    rgdal,
+    sf (>= 0.4-2),
+    sp,
+    stringr,
+    tools,
+    XML
 Suggests:
+    glue,
     knitr,
     rgrass7,
     rmarkdown,
-    testthat,
-    RSAGA
-VignetteBuilder: knitr
+    RSAGA,
+    testthat
+VignetteBuilder: 
+    knitr
+ByteCompile: true
+Encoding: UTF-8
+LazyData: TRUE
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 6.1.1
+SystemRequirements: Python (>= 3.4), QGIS (>= 3.5)

--- a/R/helper_funs.R
+++ b/R/helper_funs.R
@@ -404,13 +404,17 @@ setup_mac = function(qgis_env = set_env()) {
     qgis_python_path = glue::glue(glue::glue("{qgis_env$qgis_prefix_path}/Resources/python:/Applications/QGIS3.4.app/Contents/Frameworks/QtCore.framework/")#,
                                  #glue::glue("{qgis_env$qgis_prefix_path}/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages")
     )
+    # this is the PYTHONPATH from the QGIS interpreter in the GUI
+    qgis_python_path = "/Applications/QGIS3.4.app/Contents/MacOS/../Resources/python:/Users/pjs/Library/Application Support/QGIS/QGIS3/profiles/default/python:/Users/pjs/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins:/Applications/QGIS3.4.app/Contents/MacOS/../Resources/python/plugins:/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.7:/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages/geos:/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages:/Applications/QGIS3.4.app/Contents/Resources/python:/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python3.7/lib-dynload:/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/lib/python37.zip:/Users/pjs/Library/Application Support/QGIS/QGIS3/profiles/default/python"
   } else {
     # homebrew
     qgis_python_path = "/usr/local/opt/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/QGIS.app/Contents/Resources/python:/usr/local/opt/osgeo-gdal-python/lib/python3.7/site-packages:$PYTHONPATH"
   }
 
+  # FIXME: Works without?
   #Sys.setenv(QGIS_PREFIX_PATH = paste0(qgis_env$root, "/Contents/MacOS/"))
   Sys.setenv(PYTHONPATH = qgis_python_path)
+  # FIXME: Works without?
   #Sys.setenv(LD_LIBRARY_PATH = "/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents/MacOS/lib/:/Applications/QGIS.app/Contents/Frameworks/")
 
   # define path where QGIS libraries reside to search path of the
@@ -419,11 +423,6 @@ setup_mac = function(qgis_env = set_env()) {
   qgis_ld = glue::glue(glue::glue("{qgis_env$qgis_prefix_path}/MacOS/lib/:"),
                        glue::glue("{qgis_env$qgis_prefix_path}/Contents/Frameworks/"))
   Sys.setenv(LD_LIBRARY_PATH = qgis_ld)
-
-  #Sys.setenv(QGIS_PREFIX_PATH = "/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents")
-
-  # suppress verbose QGIS output for homebrew
-  #Sys.setenv(QGIS_DEBUG = -1)
 
   if (!grepl("homebrew", qgis_env$platform)) {
     use_python("/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3", required = TRUE)

--- a/R/helper_funs.R
+++ b/R/helper_funs.R
@@ -400,40 +400,30 @@ setup_mac = function(qgis_env = set_env()) {
   # append PYTHONPATH to import qgis.core etc. packages
   # FIXME: Currently we are overriding the PYTHONPATH variable completely -> might cause trouble for some users?
 
-  browser()
   if (!grepl("homebrew", qgis_env$platform)) {
-    qgis_python_path = glue::glue(glue::glue("{qgis_env$qgis_prefix_path}/Resources/python:"),
-                                  glue::glue("{qgis_env$qgis_prefix_path}/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages")
+    qgis_python_path = glue::glue(glue::glue("{qgis_env$qgis_prefix_path}/Resources/python:/Applications/QGIS3.4.app/Contents/Frameworks/QtCore.framework/")#,
+                                 #glue::glue("{qgis_env$qgis_prefix_path}/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages")
     )
   } else {
     # homebrew
     qgis_python_path = "/usr/local/opt/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/QGIS.app/Contents/Resources/python:/usr/local/opt/osgeo-gdal-python/lib/python3.7/site-packages:$PYTHONPATH"
   }
 
-  Sys.setenv(QGIS_PREFIX_PATH = paste0(qgis_env$root, "/Contents/MacOS/"))
+  #Sys.setenv(QGIS_PREFIX_PATH = paste0(qgis_env$root, "/Contents/MacOS/"))
   Sys.setenv(PYTHONPATH = qgis_python_path)
+  #Sys.setenv(LD_LIBRARY_PATH = "/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents/MacOS/lib/:/Applications/QGIS.app/Contents/Frameworks/")
 
   # define path where QGIS libraries reside to search path of the
   # dynamic linker
-  ld_library = Sys.getenv("LD_LIBRARY_PATH")
 
-  if (!grepl("homebrew", qgis_env$platform)) {
-    qgis_ld = glue::glue(glue::glue("{qgis_env$qgis_prefix_path}/MacOS/lib/:"),
-                         glue::glue("{qgis_env$qgis_prefix_path}/Contents/Frameworks/"))
-  } else {
-    # homebrew
-    if (ld_library != "" & !grepl(paste0(qgis_ld, ":"), ld_library)) {
-      qgis_ld = paste(
-        paste0(qgis_env$root, "/lib"),
-        Sys.getenv("LD_LIBRARY_PATH"),
-        sep = ":"
-      )
-    }
-  }
+  qgis_ld = glue::glue(glue::glue("{qgis_env$qgis_prefix_path}/MacOS/lib/:"),
+                       glue::glue("{qgis_env$qgis_prefix_path}/Contents/Frameworks/"))
   Sys.setenv(LD_LIBRARY_PATH = qgis_ld)
 
+  #Sys.setenv(QGIS_PREFIX_PATH = "/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents")
+
   # suppress verbose QGIS output for homebrew
-  Sys.setenv(QGIS_DEBUG = -1)
+  #Sys.setenv(QGIS_DEBUG = -1)
 
   if (!grepl("homebrew", qgis_env$platform)) {
     use_python("/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3", required = TRUE)

--- a/R/helper_funs.R
+++ b/R/helper_funs.R
@@ -398,21 +398,16 @@ setup_linux = function(qgis_env = set_env()) {
 setup_mac = function(qgis_env = set_env()) {
 
   # append PYTHONPATH to import qgis.core etc. packages
-  python_path = Sys.getenv("PYTHONPATH")
+  # FIXME: Currently we are overriding the PYTHONPATH variable completely -> might cause trouble for some users?
 
-  # python packages of QGIS are stored in '/usr/local/opt/osgeo-qgis/QGIS.app/Contents/Resources/python'
-  qgis_python_path = "/usr/local/opt/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/QGIS.app/Contents/Resources/python:/usr/local/opt/osgeo-gdal-python/lib/python3.7/site-packages:$PYTHONPATH"
-    # paste0(qgis_env$root, paste(
-    #   "/Contents/Resources/python/",
-    #   #"/usr/local/lib/qt-4/python3.6/site-packages",
-    #   "/usr/local/lib/python3.7/site-packages",
-    #   "$PYTHONPATH", sep = ":"
-    # ))
-  if (python_path != "" & !grepl(qgis_python_path, python_path)) {
-    qgis_python_path = paste(
-      qgis_python_path, Sys.getenv("PYTHONPATH"),
-      sep = ":"
+  browser()
+  if (!grepl("homebrew", qgis_env$platform)) {
+    qgis_python_path = glue::glue(glue::glue("{qgis_env$qgis_prefix_path}/Resources/python:"),
+                                  glue::glue("{qgis_env$qgis_prefix_path}/Frameworks/Python.framework/Versions/Current/lib/python3.7/site-packages")
     )
+  } else {
+    # homebrew
+    qgis_python_path = "/usr/local/opt/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/QGIS.app/Contents/Resources/python:/usr/local/opt/osgeo-gdal-python/lib/python3.7/site-packages:$PYTHONPATH"
   }
 
   Sys.setenv(QGIS_PREFIX_PATH = paste0(qgis_env$root, "/Contents/MacOS/"))
@@ -422,36 +417,29 @@ setup_mac = function(qgis_env = set_env()) {
   # dynamic linker
   ld_library = Sys.getenv("LD_LIBRARY_PATH")
 
-  qgis_ld = paste(paste0(
-    qgis_env$qgis_prefix_path,
-    file.path(
-      "/MacOS/lib/:/Applications/QGIS3.app/",
-      "Contents/Frameworks/"
-    )
-  )) # homebrew
-  if (ld_library != "" & !grepl(paste0(qgis_ld, ":"), ld_library)) {
-    qgis_ld = paste(
-      paste0(qgis_env$root, "/lib"),
-      Sys.getenv("LD_LIBRARY_PATH"),
-      sep = ":"
-    )
+  if (!grepl("homebrew", qgis_env$platform)) {
+    qgis_ld = glue::glue(glue::glue("{qgis_env$qgis_prefix_path}/MacOS/lib/:"),
+                         glue::glue("{qgis_env$qgis_prefix_path}/Contents/Frameworks/"))
+  } else {
+    # homebrew
+    if (ld_library != "" & !grepl(paste0(qgis_ld, ":"), ld_library)) {
+      qgis_ld = paste(
+        paste0(qgis_env$root, "/lib"),
+        Sys.getenv("LD_LIBRARY_PATH"),
+        sep = ":"
+      )
+    }
   }
   Sys.setenv(LD_LIBRARY_PATH = qgis_ld)
 
   # suppress verbose QGIS output for homebrew
   Sys.setenv(QGIS_DEBUG = -1)
 
-  # FIXME
-  # when using kyngchaos check for python3 installation
-
-
-  # make sure to use Python3
-  # in QGIS Python console run
-  # import sys
-  # sys.version  # which python version is used
-  # sys.exectutable  # and where to find the executable
-  # use_python("/usr/bin/python2.7", required = TRUE)
-  use_python("/usr/local/bin/python3", required = TRUE)
+  if (!grepl("homebrew", qgis_env$platform)) {
+    use_python("/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3", required = TRUE)
+  } else {
+    use_python("/usr/local/bin/python3", required = TRUE)
+  }
 }
 
 #' @title Save spatial objects

--- a/R/processing.R
+++ b/R/processing.R
@@ -1,6 +1,6 @@
 #' @title Retrieve the environment settings to run QGIS from within R
-#' @description `set_env()` tries to find all the paths necessary to run QGIS from
-#'   within R.
+#' @description `set_env()` tries to find all the paths necessary to run QGIS
+#'   from within R.
 #' @importFrom stringr str_detect
 #' @param root Root path to the QGIS-installation. If left empty, the function
 #'   looks for `qgis.bat` first in the most likely locations (C:/OSGEO4~1,
@@ -13,6 +13,9 @@
 #'   even if you used new values for function arguments `root` and/or `dev`.
 #' @param dev If set to `TRUE`, `set_env()` will use the development version of
 #'   QGIS3 (if available).
+#' @param homebrew Prefer QGIS installation via homebrew when setting the
+#'   environment? Only applies to macOS. Currently, only homebrew installations
+#'   are supported.
 #' @param ... Currently not in use.
 #' @return The function returns a list containing all the path necessary to run
 #'   QGIS from within R. This is the root path, the QGIS prefix path and the
@@ -39,6 +42,8 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, homebrew = TRUE, ...) 
 
   if (Sys.info()["sysname"] == "Windows") {
     if (is.null(root)) {
+
+      platform = "Windows"
       # raw command
       # change to C: drive and (&) list all subfolders of C:
       # /b bare format (no heading, file sizes or summary)
@@ -100,6 +105,7 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, homebrew = TRUE, ...) 
     if (is.null(root)) {
 
       if (!homebrew) {
+        stop("Currently only QGIS installations from homebrew are supported.")
         message("Checking for non-homebrew QGIS installation only.")
 
         path = system("find /Applications -name 'QGIS3*.app'", intern = TRUE)
@@ -109,7 +115,6 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, homebrew = TRUE, ...) 
         }
         platform = "macOS"
       } else {
-
 
         message("Checking for homebrew osgeo4mac installation on your system. \n")
         # check for homebrew QGIS installation
@@ -123,9 +128,7 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, homebrew = TRUE, ...) 
         no_homebrew = str_detect(path, "find: /usr/local")
 
         if (length(no_homebrew) == 0L) {
-          message(paste0(
-            "Found no QGIS homebrew installation."
-          ))
+          stop("Found no QGIS homebrew installation.")
         }
         if (no_homebrew == FALSE && length(path) == 1) {
           root = path
@@ -196,6 +199,7 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, homebrew = TRUE, ...) 
 
   if (Sys.info()["sysname"] == "Linux") {
     if (is.null(root)) {
+      platform = "Linux"
       message("Assuming that your root path is '/usr'!")
       root = "/usr"
     }

--- a/R/processing.R
+++ b/R/processing.R
@@ -29,7 +29,7 @@
 #'
 #' @export
 #' @author Jannes Muenchow, Patrick Schratz
-set_env = function(root = NULL, new = FALSE, dev = FALSE, ...) {
+set_env = function(root = NULL, new = FALSE, dev = FALSE, homebrew = TRUE, ...) {
   # ok, let's try to find QGIS first in the most likely place!
   dots = list(...)
   # load cached qgis_env if possible
@@ -98,97 +98,100 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, ...) {
 
   if (Sys.info()["sysname"] == "Darwin") {
     if (is.null(root)) {
-      message("Checking for homebrew osgeo4mac installation on your system. \n")
-      # check for homebrew QGIS installation
-      path = suppressWarnings(
-        system2(
-          "find", c("/usr/local/Cellar", "-name", "QGIS.app"),
-          stdout = TRUE, stderr = TRUE
-        )
-      )
 
-      no_homebrew = str_detect(path, "find: /usr/local")
+      if (!homebrew) {
+        message("Checking for non-homebrew QGIS installation only.")
 
-      if (length(no_homebrew) == 0L) {
-        message(paste0(
-          "Found no QGIS homebrew installation. ",
-          "Checking for other QGIS installations now."
-        ))
-      }
-      if (no_homebrew == FALSE && length(path) == 1) {
-        root = path
-        message("Found QGIS osgeo4mac installation. Setting environment...")
-      }
-
-      # check for multiple homebrew installations
-      if (length(path) >= 2) {
-
-        # extract version out of root path
-        path1 =
-          as.numeric(regmatches(path[1], gregexpr("[0-9]+", path[1]))[[1]][1])
-        path2 =
-          as.numeric(regmatches(path[2], gregexpr("[0-9]+", path[2]))[[1]][1])
-        if (length(path) == 3) {
-          path3 =
-            as.numeric(regmatches(path[3], gregexpr("[0-9]+", path[3]))[[1]][1])
-        }
-
-        if (!3 %in% c(path1, path2)) {
-          if (2 %in% c(path1, path2)) {
-            stop("A QGIS2 installation was found but no QGIS3 installation. Please install QGIS3.")
-          } else {
-            stop("No QGIS installation was found in your system.")
-          }
-        }
-        # account for 'dev' arg installations are not constant within path ->
-        # depend on which version was installed first/last hence we have to
-        # catch all possibilites
-
-        # extract version out of root path
-        path1 =
-          as.numeric(regmatches(path[1], gregexpr("[0-9]+", path[1]))[[1]][2])
-        path2 =
-          as.numeric(regmatches(path[2], gregexpr("[0-9]+", path[2]))[[1]][2])
-        if (length(path) == 3) {
-          path3 =
-            as.numeric(regmatches(path[3], gregexpr("[0-9]+", path[3]))[[1]][3])
-        }
-        if (dev == TRUE && path1 > path2) {
-          root <- path[1]
-          message("Found QGIS osgeo4mac DEV installation. Setting environment...")
-        } else if (dev == TRUE && path1 < path2) {
-          root <- path[2]
-          message("Found QGIS osgeo4mac DEV installation. Setting environment...")
-        } else if (dev == FALSE && path1 > path2) {
-          root <- path[2]
-          message("Found QGIS osgeo4mac LTR installation. Setting environment...")
-        } else if (dev == FALSE && path1 < path2) {
-          root <- path[1]
-          message("Found QGIS osgeo4mac LTR installation. Setting environment...")
-        }
-
-        if (path1 > path2 && path1 == 3) {
-          root = path[1]
-          message("Found QGIS3 osgeo4mac installation. Setting environment...")
-        } else if (path2 > path1 && path2 == 3) {
-          root = path[2]
-          message("Found QGIS3 osgeo4mac installation. Setting environment...")
-        }
-
-        platform = "macOS (homebrew)"
-      }
-
-      # check for QGIS binary installation
-      if (is.null(root)) {
         path = system("find /Applications -name 'QGIS3*.app'", intern = TRUE)
         if (length(path) > 0) {
           root = path
           message("Found a QGIS3 installation. Setting environment...")
         }
         platform = "macOS"
+      } else {
+
+
+        message("Checking for homebrew osgeo4mac installation on your system. \n")
+        # check for homebrew QGIS installation
+        path = suppressWarnings(
+          system2(
+            "find", c("/usr/local/Cellar", "-name", "QGIS.app"),
+            stdout = TRUE, stderr = TRUE
+          )
+        )
+
+        no_homebrew = str_detect(path, "find: /usr/local")
+
+        if (length(no_homebrew) == 0L) {
+          message(paste0(
+            "Found no QGIS homebrew installation."
+          ))
+        }
+        if (no_homebrew == FALSE && length(path) == 1) {
+          root = path
+          message("Found QGIS osgeo4mac installation. Setting environment...")
+          platform = "macOS (homebrew)"
+        }
+
+        # check for multiple homebrew installations
+        if (length(path) >= 2) {
+
+          # extract version out of root path
+          path1 =
+            as.numeric(regmatches(path[1], gregexpr("[0-9]+", path[1]))[[1]][1])
+          path2 =
+            as.numeric(regmatches(path[2], gregexpr("[0-9]+", path[2]))[[1]][1])
+          if (length(path) == 3) {
+            path3 =
+              as.numeric(regmatches(path[3], gregexpr("[0-9]+", path[3]))[[1]][1])
+          }
+
+          if (!3 %in% c(path1, path2)) {
+            if (2 %in% c(path1, path2)) {
+              stop("A QGIS2 installation was found but no QGIS3 installation. Please install QGIS3.")
+            } else {
+              stop("No QGIS installation was found in your system.")
+            }
+          }
+          # account for 'dev' arg installations are not constant within path ->
+          # depend on which version was installed first/last hence we have to
+          # catch all possibilites
+
+          # extract version out of root path
+          path1 =
+            as.numeric(regmatches(path[1], gregexpr("[0-9]+", path[1]))[[1]][2])
+          path2 =
+            as.numeric(regmatches(path[2], gregexpr("[0-9]+", path[2]))[[1]][2])
+          if (length(path) == 3) {
+            path3 =
+              as.numeric(regmatches(path[3], gregexpr("[0-9]+", path[3]))[[1]][3])
+          }
+          if (dev == TRUE && path1 > path2) {
+            root <- path[1]
+            message("Found QGIS osgeo4mac DEV installation. Setting environment...")
+          } else if (dev == TRUE && path1 < path2) {
+            root <- path[2]
+            message("Found QGIS osgeo4mac DEV installation. Setting environment...")
+          } else if (dev == FALSE && path1 > path2) {
+            root <- path[2]
+            message("Found QGIS osgeo4mac LTR installation. Setting environment...")
+          } else if (dev == FALSE && path1 < path2) {
+            root <- path[1]
+            message("Found QGIS osgeo4mac LTR installation. Setting environment...")
+          }
+
+          if (path1 > path2 && path1 == 3) {
+            root = path[1]
+            message("Found QGIS3 osgeo4mac installation. Setting environment...")
+          } else if (path2 > path1 && path2 == 3) {
+            root = path[2]
+            message("Found QGIS3 osgeo4mac installation. Setting environment...")
+          }
+
+          platform = "macOS (homebrew)"
+        }
       }
     }
-
   }
 
   if (Sys.info()["sysname"] == "Linux") {
@@ -406,7 +409,7 @@ qgis_session_info = function(qgis_env = set_env()) {
   tmp = try(expr = open_app(qgis_env = qgis_env), silent = TRUE)
 
   # suppress R CMD check note
-  py = NULL
+  #py = NULL
 
   # retrieve the output
   suppressWarnings({
@@ -495,7 +498,7 @@ find_algorithms = function(search_term = NULL, name_only = FALSE,
   tmp = try(expr = open_app(qgis_env = qgis_env), silent = TRUE)
 
   # suppress R CMD check note
-  py = NULL
+  # py = NULL
 
   # Advantage of this approach: we are using directly alglist and do not have to
   # save it in inst

--- a/R/processing.R
+++ b/R/processing.R
@@ -96,7 +96,6 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, ...) {
     root = gsub("/{1,}$", "", root)
   }
 
-  browser()
   if (Sys.info()["sysname"] == "Darwin") {
     if (is.null(root)) {
       message("Checking for homebrew osgeo4mac installation on your system. \n")
@@ -113,7 +112,7 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, ...) {
       if (length(no_homebrew) == 0L) {
         message(paste0(
           "Found no QGIS homebrew installation. ",
-          "Checking for QGIS Kyngchaos version now."
+          "Checking for other QGIS installations now."
         ))
       }
       if (no_homebrew == FALSE && length(path) == 1) {
@@ -175,17 +174,21 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, ...) {
           root = path[2]
           message("Found QGIS3 osgeo4mac installation. Setting environment...")
         }
+
+        platform = "macOS (homebrew)"
       }
 
-      # check for Kyngchaos installation
+      # check for QGIS binary installation
       if (is.null(root)) {
-        path = system("find /Applications -name 'QGIS3.app'", intern = TRUE)
+        path = system("find /Applications -name 'QGIS3*.app'", intern = TRUE)
         if (length(path) > 0) {
           root = path
-          message("Found QGIS Kyngchaos installation. Setting environment...")
+          message("Found a QGIS3 installation. Setting environment...")
         }
+        platform = "macOS"
       }
     }
+
   }
 
   if (Sys.info()["sysname"] == "Linux") {
@@ -202,20 +205,19 @@ set_env = function(root = NULL, new = FALSE, dev = FALSE, ...) {
   }
   qgis_env = list(root = root)
   qgis_env = c(qgis_env, check_apps(root = root))
+  qgis_env = c(qgis_env, platform = platform)
   assign("qgis_env", qgis_env, envir = .RQGIS_cache)
 
-
-  # write warning if Kyngchaos QGIS for Mac is installed
-  if (any(grepl("/Applications", qgis_env))) {
-    warning(
-      paste0(
-        "We recognized that you are using the QGIS binary.\n",
-        "Please consider installing QGIS from homebrew:",
-        "'https://github.com/OSGeo/homebrew-osgeo4mac'.",
-        " Run 'vignette(install_guide)' for installation instructions.\n"
-      )
-    )
-  }
+  # if (any(grepl("/Applications", qgis_env))) {
+  #   warning(
+  #     paste0(
+  #       "We recognized that you are not using the QGIS installation from 'homebrew'.\n",
+  #       "Please consider installing QGIS from homebrew:",
+  #       "'https://github.com/OSGeo/homebrew-osgeo4mac'.",
+  #       " Run 'vignette(install_guide)' for installation instructions.\n"
+  #     )
+  #   )
+  # }
 
   # return your result
   qgis_env

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,47 +6,39 @@ init:
         $ErrorActionPreference = "Stop"
         Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
         Import-Module '..\appveyor-tool.ps1'
+
 install:
   - ps: Bootstrap
-  - cmd: R -q -e "writeLines('options(repos = \'https://cloud.r-project.org\')', '~/.Rprofile')"
-  - cmd: R -q -e "getOption('repos')"
-  - cmd: R -q -e "install.packages('remotes'); remotes::install_github('ropenscilabs/tic'); tic::prepare_all_stages()"
+  - cmd: Rscript -e "writeLines('options(repos = \'https://cloud.r-project.org\')', '~/.Rprofile')"
+  - cmd: Rscript -e "getOption('repos')"
+  - cmd: Rscript -e "if (!requireNamespace('remotes')) install.packages('remotes', type = 'binary')"
+  - cmd: Rscript -e "if (getRversion() < '3.2' && !requireNamespace('curl')) install.packages('curl', type = 'binary')"
+  - cmd: Rscript -e "options(pkgType = 'binary'); remotes::install_github('ropenscilabs/tic', upgrade = 'always'); print(tic::dsl_load()); tic::prepare_all_stages()"
 
-cache:
-- C:\RLibrary
-- 'C:\Program Files\QGIS 2.18'
-
-before_test:
- - ps: >-
-      if (-Not (Test-Path "C:\Program Files\QGIS 2.18")) {
-        cinst qgis-ltr
-      }
- - ps: $env:Path += ";C:\Program Files\QGIS 2.18"
- #- ps: Get-ChildItem -Path 'C:\Program Files\QGIS 2.18'
-
-before_build: R -q -e "tic::before_install()"
-build_script: R -q -e "tic::install()"
-after_build: R -q -e "tic::after_install()"
-test_script: R -q -e "tic::script()"
-# on_success: R -q -e "try(tic::after_success(), silent = TRUE)" # we run covr on Travis
-on_failure: R -q -e "tic::after_failure()"
-before_deploy: R -q -e "tic::before_deploy()"
-deploy_script: R -q -e "tic::deploy()"
-after_deploy: R -q -e "tic::after_deploy()"
-on_finish: R -q -e "tic::after_script()"
-
-
-environment:
-  global:
-    USE_RTOOLS: true
-  R_ARCH: x64
-  NOT_CRAN: true # https://github.com/krlmlr/r-appveyor/issues/108
+before_build: Rscript -e "tic::before_install()"
+build_script: Rscript -e "tic::install()"
+after_build: Rscript -e "tic::after_install()"
+before_test: Rscript -e "tic::before_script()"
+test_script: Rscript -e "tic::script()"
+on_success: Rscript -e "try(tic::after_success(), silent = TRUE)"
+on_failure: Rscript -e "tic::after_failure()"
+before_deploy: Rscript -e "tic::before_deploy()"
+deploy_script: Rscript -e "tic::deploy()"
+after_deploy: Rscript -e "tic::after_deploy()"
+on_finish: Rscript -e "tic::after_script()"
 
 # Adapt as necessary starting from here
 
 #on_failure:
 #  - 7z a failure.zip *.Rcheck\*
 #  - appveyor PushArtifact failure.zip
+
+#environment:
+  # The example below will not work for your repository,
+  # you need to encrypt your own token.
+  # Please follow https://ci.appveyor.com/tools/encrypt .
+  #GITHUB_PAT:
+  #  secure: VXO22OHLkl4YhVIomSMwCZyOTx03Xf2WICaVng9xH7gISlAg8a+qrt1DtFtk8sK5
 
 artifacts:
   - path: '*.Rcheck\**\*.log'
@@ -66,4 +58,3 @@ artifacts:
 
   - path: '\*_*.zip'
     name: Bits
-    

--- a/inst/test-scripts/mac_run_qgis.R
+++ b/inst/test-scripts/mac_run_qgis.R
@@ -3,22 +3,43 @@
 #********************************************************
 
 devtools::load_all()
-use_python("/usr/local/bin/python3")
 
-Sys.setenv(LD_LIBRARY_PATH = paste("/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents/MacOS/lib/:/Applications/QGIS.app/Contents/Frameworks/"))
 
-Sys.setenv(PYTHONPATH = "PYTHONPATH=/usr/local/opt/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/QGIS.app/Contents/Resources/python:/usr/local/opt/osgeo-gdal-python/lib/python3.7/site-packages:$PYTHONPATH")
-
+# homebrew ---------------------------------------------------------------------
+Sys.setenv(LD_LIBRARY_PATH = "/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents/MacOS/lib/:/Applications/QGIS.app/Contents/Frameworks/")
+Sys.setenv(PYTHONPATH = "/usr/local/opt/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/lib/python3.7/site-packages:/usr/local/opt/osgeo-qgis/QGIS.app/Contents/Resources/python:/usr/local/opt/osgeo-gdal-python/lib/python3.7/site-packages:$PYTHONPATH")
 Sys.setenv(QGIS_PREFIX_PATH = "/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents/MacOS/")
+# non-homebrew -----------------------------------------------------------------
+
+# Pythonpath is the problem
+# if we take the pythonpath from above, it works
+# /usr/local/opt/osgeo-qgis/lib/python3.7/site-packages/ is missing for non-homebrew
+# this folder contains the PyQt5 python resources and a link to the qgis processing modules
+# Q: Where are the QGIS processing libs??
+Sys.setenv(LD_LIBRARY_PATH = "/Applications/QGIS3.4.app/Contents/MacOS/lib:/Applications/QGIS3.4.app/Contents/Frameworks")
+Sys.setenv(PYTHONPATH = "/Applications/QGIS3.4.app/Contents/Resources/python:$PYTHONPATH")
+Sys.setenv(QGIS_PREFIX_PATH = "/Applications/QGIS3.4.app/Contents/MacOS/")
 Sys.setenv(QGIS_DEBUG=-1)
 
-# reproducing our py_cmd.py
+# homebrew ---------------------------------------------------------------------
+#use_python("/usr/local/bin/python3")
+# non-homebrew -----------------------------------------------------------------
+reticulate::use_python("/Applications/QGIS3.4.app/Contents/Frameworks/Python.framework/Versions/Current/bin/python3", required = TRUE)
+
+
 py_run_string("import os, re, sys")
 py_run_string("from qgis.core import *")
 py_run_string("from osgeo import ogr")
 py_run_string("from PyQt5.QtCore import *")
 py_run_string("from PyQt5.QtGui import *")
 py_run_string("from qgis.gui import *")
+
+# non-homebrew -----------------------------------------------------------------
+
+py_run_string("sys.path.append(r'/Applications/QGIS3.4.app/Contents/Resources/python/plugins')")
+py_run_string("QgsApplication.setPrefixPath(r'/Applications/QGIS3.4.app/Contents/', True)")
+
+# homebrew ---------------------------------------------------------------------
 
 py_run_string("sys.path.append(r'/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents/Resources/python/plugins')")
 py_run_string("QgsApplication.setPrefixPath(r'/usr/local/Cellar/osgeo-qgis/3.8.0_1/QGIS.app/Contents', True)")
@@ -27,22 +48,6 @@ py_eval("QgsApplication.showSettings()")
 py_run_string("app = QgsApplication([], True)")
 
 py_run_string("QgsApplication.initQgis()")
-
-py_run_string("from qgis.core import (QgsSettings,
-                       QgsProcessingFeedback,
-                       Qgis,
-                       QgsMessageLog,
-                       QgsApplication,
-                       QgsMapLayer,
-                       QgsProcessingProvider,
-                       QgsProcessingAlgorithm,
-                       QgsProcessingException,
-                       QgsProcessingParameterDefinition,
-                       QgsProcessingParameterEnum,
-                       QgsProcessingOutputVectorLayer,
-                       QgsProcessingOutputRasterLayer,
-                       QgsProcessingOutputMapLayer,
-                       QgsProcessingOutputMultipleLayers)")
 
 py_run_string("from processing.tools.general import algorithmHelp
 from processing.algs.saga.SagaAlgorithmProvider import SagaAlgorithmProvider

--- a/man/set_env.Rd
+++ b/man/set_env.Rd
@@ -4,7 +4,8 @@
 \alias{set_env}
 \title{Retrieve the environment settings to run QGIS from within R}
 \usage{
-set_env(root = NULL, new = FALSE, dev = FALSE, ...)
+set_env(root = NULL, new = FALSE, dev = FALSE, homebrew = TRUE,
+  ...)
 }
 \arguments{
 \item{root}{Root path to the QGIS-installation. If left empty, the function
@@ -21,6 +22,10 @@ even if you used new values for function arguments \code{root} and/or \code{dev}
 \item{dev}{If set to \code{TRUE}, \code{set_env()} will use the development version of
 QGIS3 (if available).}
 
+\item{homebrew}{Prefer QGIS installation via homebrew when setting the
+environment? Only applies to macOS. Currently, only homebrew installations
+are supported.}
+
 \item{...}{Currently not in use.}
 }
 \value{
@@ -29,8 +34,8 @@ QGIS from within R. This is the root path, the QGIS prefix path and the
 path to the Python plugins.
 }
 \description{
-\code{set_env()} tries to find all the paths necessary to run QGIS from
-within R.
+\code{set_env()} tries to find all the paths necessary to run QGIS
+from within R.
 }
 \examples{
 \dontrun{

--- a/tic.R
+++ b/tic.R
@@ -1,15 +1,5 @@
-add_package_checks()
+do_package_checks()
 
-if (Sys.getenv("id_rsa") != "") {
-  # pkgdown documentation can be built optionally. Other example criteria:
-  # - `inherits(ci(), "TravisCI")`: Only for Travis CI
-  # - `ci()$is_tag()`: Only for tags, not for branches
-  # - `Sys.getenv("BUILD_PKGDOWN") != ""`: If the env var "BUILD_PKGDOWN" is set
-  # - `Sys.getenv("TRAVIS_EVENT_TYPE") == "cron"`: Only for Travis cron jobs
-  get_stage("before_deploy") %>%
-    add_step(step_setup_ssh())
-  
-  get_stage("deploy") %>%
-    add_step(step_build_pkgdown()) %>%
-    add_step(step_push_deploy(path = "docs", branch = "gh-pages"))
+if (ci_on_travis()) {
+  do_pkgdown()
 }

--- a/vignettes/install_guide.Rmd
+++ b/vignettes/install_guide.Rmd
@@ -284,16 +284,5 @@ Otherwise, pre-built bottles (= binaries) will be used which speeds up the insta
 
 2. Using the official QGIS binary
 
-If you do not (want to) use `homebrew`, you can install the QGIS binary from [https://www.qgis.org/en/site/forusers/download.html](https://www.qgis.org/en/site/forusers/download.html). 
-
-If you choose this option, you will get the following error messages during QGIS processing
-
-```
-QSqlDatabase: QSQLITE driver not loaded
-QSqlDatabase: available drivers:
-QSqlQuery::prepare: database not open
-[1] "ERROR: Opening of authentication db FAILED"
-[2] "WARNING: Auth db query exec() FAILED"
-```
-
-These messages **DO NOT affect RQGIS usage**. 
+We currently do not support the QGIS installer from https://www.qgis.org/en/site/forusers/download.html  due to technical issues getting it working with RQGIS3.
+We may add support for it in the future.


### PR DESCRIPTION
I was not able to get RQGIS3 working with the official QGIS installer.
See https://gis.stackexchange.com/questions/333540/loading-pyqt5-modules-from-qgis3-pyqgis for the blocking issue.

Therefore I decided that we do not support it for now. We stop early if no homebrew installation is found.
This requirement is now also reflected in the vignette.

In addition I tidied the code and removed some lines setting certain env values which are apparently not required to run successfully.

I've added argument `homebrew` to `set_env()` to let users decide which installation they want to use (even thought we only support homebrew for now).
This may seem unnecessary for the user at first but I need this internally to conditionally set things depending on the QGIS installation way.

## Other changes

- Get Travis running on macOS and Linux (I'll try to get a green build before merging)